### PR TITLE
Feature/change from guid to string

### DIFF
--- a/Dot.NetCore.Identity.MongoDb/IdentityObjectCollection.cs
+++ b/Dot.NetCore.Identity.MongoDb/IdentityObjectCollection.cs
@@ -36,7 +36,7 @@ namespace Dot.NetCore.Identity.MongoDb
 			return await FirstOrDefaultAsync(item => item.Id == itemId);
 		}
 
-
+		#pragma warning disable CS1998
 		public async Task<IEnumerable<TItem>> GetAll()
 		{
 			return MongoCollection.AsQueryable();

--- a/Dot.NetCore.Identity.MongoDb/IdentityObjectCollection.cs
+++ b/Dot.NetCore.Identity.MongoDb/IdentityObjectCollection.cs
@@ -31,7 +31,7 @@ namespace Dot.NetCore.Identity.MongoDb
 
 		private IMongoCollection<TItem> MongoCollection { get; }
 
-		public async Task<TItem> FindByIdAsync(Guid itemId)
+		public async Task<TItem> FindByIdAsync(string itemId)
 		{
 			return await FirstOrDefaultAsync(item => item.Id == itemId);
 		}

--- a/Dot.NetCore.Identity.MongoDb/IdentityRoleCollection.cs
+++ b/Dot.NetCore.Identity.MongoDb/IdentityRoleCollection.cs
@@ -16,10 +16,5 @@ namespace Dot.NetCore.Identity.MongoDb
 		{
 			return await FirstOrDefaultAsync(x => x.NormalizedName == normalizedName);
 		}
-
-		public async Task<TRole> FindByIdAsync(string roleId)
-		{
-			return await FirstOrDefaultAsync(x => x.Id == roleId);
-		}
 	}
 }

--- a/Dot.NetCore.Identity.MongoDb/IdentityRoleCollection.cs
+++ b/Dot.NetCore.Identity.MongoDb/IdentityRoleCollection.cs
@@ -17,7 +17,7 @@ namespace Dot.NetCore.Identity.MongoDb
 			return await FirstOrDefaultAsync(x => x.NormalizedName == normalizedName);
 		}
 
-		public async Task<TRole> FindByIdAsync(Guid roleId)
+		public async Task<TRole> FindByIdAsync(string roleId)
 		{
 			return await FirstOrDefaultAsync(x => x.Id == roleId);
 		}

--- a/Dot.NetCore.Identity.Service/BaseApiController.cs
+++ b/Dot.NetCore.Identity.Service/BaseApiController.cs
@@ -25,7 +25,7 @@ namespace Dot.NetCore.Identity.Service
 			}
 			catch (Exception e)
 			{
-				Log.LogError($"Request  failed: {Request.Path}");
+				Log.LogError($"Request  failed: {Request.Path}. Error: {e.Message}");
 				throw;
 			}
 		}

--- a/Dot.NetCore.Identity.Service/BaseRolesController.cs
+++ b/Dot.NetCore.Identity.Service/BaseRolesController.cs
@@ -43,7 +43,7 @@ namespace Dot.NetCore.Identity.Service
 		}
 
 		[HttpGet("{itemId}")]
-		public async Task<TRole> FindByIdAsync(Guid itemId)
+		public async Task<TRole> FindByIdAsync(string itemId)
 		{
 			return await ExecuteWithLog(async () => await _Collection.FindByIdAsync(itemId));
 		}

--- a/Dot.NetCore.Identity.Service/BaseUsersController.cs
+++ b/Dot.NetCore.Identity.Service/BaseUsersController.cs
@@ -43,7 +43,7 @@ namespace Dot.NetCore.Identity.Service
 		}
 
 		[HttpGet("{itemId}")]
-		public async Task<TUser> FindByIdAsync(Guid itemId)
+		public async Task<TUser> FindByIdAsync(string itemId)
 		{
 			return await ExecuteWithLog(async () => await _Collection.FindByIdAsync(itemId));
 		}

--- a/Dot.NetCore.Identity.ServiceProxy/IdentityObjectCollectionProxy.cs
+++ b/Dot.NetCore.Identity.ServiceProxy/IdentityObjectCollectionProxy.cs
@@ -113,7 +113,7 @@ namespace Dot.NetCore.Identity.ServiceProxy
 			});
 		}
 
-		public async Task<TItem> FindByIdAsync(Guid itemId)
+		public async Task<TItem> FindByIdAsync(string itemId)
 		{
 			return await Execute<TItem>("{id}", r => { r.AddUrlSegment("id", itemId); });
 		}

--- a/Dot.NetCore.Identity/Model/IdentityObject.cs
+++ b/Dot.NetCore.Identity/Model/IdentityObject.cs
@@ -4,6 +4,6 @@ namespace Dot.NetCore.Identity.Model
 {
 	public abstract class IdentityObject
 	{
-		public Guid Id { get; set; } = Guid.NewGuid();
+		public string Id { get; set; } = Guid.NewGuid().ToString();
 	}
 }

--- a/Dot.NetCore.Identity/Stores/IIdentityObjectCollection.cs
+++ b/Dot.NetCore.Identity/Stores/IIdentityObjectCollection.cs
@@ -11,6 +11,6 @@ namespace Dot.NetCore.Identity.Stores
 		Task<TItem> CreateAsync(TItem obj);
 		Task UpdateAsync(TItem obj);
 		Task DeleteAsync(TItem obj);
-		Task<TItem> FindByIdAsync(Guid itemId);
+		Task<TItem> FindByIdAsync(string itemId);
 	}
 }

--- a/Dot.NetCore.Identity/Stores/RoleStore.cs
+++ b/Dot.NetCore.Identity/Stores/RoleStore.cs
@@ -67,8 +67,8 @@ namespace Dot.NetCore.Identity.Stores
 
 		async Task<TRole> IRoleStore<TRole>.FindByIdAsync(string roleId, CancellationToken cancellationToken)
 		{
-			if (!Guid.TryParse(roleId, out var id)) throw new ApplicationException("Invalid role Id");
-			return await _collection.FindByIdAsync(id.ToString());
+			if (!roleId.IsGuid()) throw new ApplicationException("Invalid role Id");
+			return await _collection.FindByIdAsync(roleId);
 		}
 
 		async Task<TRole> IRoleStore<TRole>.FindByNameAsync(string normalizedRoleName, CancellationToken cancellationToken)

--- a/Dot.NetCore.Identity/Stores/RoleStore.cs
+++ b/Dot.NetCore.Identity/Stores/RoleStore.cs
@@ -68,7 +68,7 @@ namespace Dot.NetCore.Identity.Stores
 		async Task<TRole> IRoleStore<TRole>.FindByIdAsync(string roleId, CancellationToken cancellationToken)
 		{
 			if (!Guid.TryParse(roleId, out var id)) throw new ApplicationException("Invalid role Id");
-			return await _collection.FindByIdAsync(id);
+			return await _collection.FindByIdAsync(id.ToString());
 		}
 
 		async Task<TRole> IRoleStore<TRole>.FindByNameAsync(string normalizedRoleName, CancellationToken cancellationToken)

--- a/Dot.NetCore.Identity/Stores/StringExtensions.cs
+++ b/Dot.NetCore.Identity/Stores/StringExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Dot.NetCore.Identity.Stores
+{
+    public static class StringExtensions
+    {
+        public static bool IsGuid(this string text)
+        {
+            return Guid.TryParse(text, out var _);
+        }
+    }
+}

--- a/Dot.NetCore.Identity/Stores/UserStore.cs
+++ b/Dot.NetCore.Identity/Stores/UserStore.cs
@@ -108,7 +108,7 @@ namespace Dot.NetCore.Identity.Stores
 		public Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
 		{
 			if (!Guid.TryParse(userId, out var id)) throw new ApplicationException("Invalid user Id");
-			return _userCollection.FindByIdAsync(id);
+			return _userCollection.FindByIdAsync(id.ToString());
 		}
 
 		public Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)

--- a/Dot.NetCore.Identity/Stores/UserStore.cs
+++ b/Dot.NetCore.Identity/Stores/UserStore.cs
@@ -107,8 +107,8 @@ namespace Dot.NetCore.Identity.Stores
 
 		public Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
 		{
-			if (!Guid.TryParse(userId, out var id)) throw new ApplicationException("Invalid user Id");
-			return _userCollection.FindByIdAsync(id.ToString());
+			if (!userId.IsGuid()) throw new ApplicationException("Invalid user Id");
+			return _userCollection.FindByIdAsync(userId.ToString());
 		}
 
 		public Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)


### PR DESCRIPTION
Changes the IdentityObject's Identity from being a Guid type to String. This is used to utilize a string identifier in MongoDB rather than the native representation of a Guid. In addition this PR fixes a few console warning messages.